### PR TITLE
Add the waypoint question into the hint.

### DIFF
--- a/index.php
+++ b/index.php
@@ -163,6 +163,7 @@ $values = [
     'includeWaypointDescription' => true,
     'includeCacheDescription' => true,
     'includeAwardMessage' => false,
+    'questionAsHint' => false,
 
     'excludeOwner' => '',
     'findsHtml' => '',
@@ -477,6 +478,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <label>
                     <input type="hidden" name="includeQuestion" value="0">
                     <input type="checkbox" name="includeQuestion"<?php echo($values['includeQuestion'] ? ' checked="checked"' : ''); ?> /> <?php echo $LANG['LABEL_INCLUDE_QUESTION']; ?>
+                </label>
+            </div>
+            <div class="form-row">
+                <label>
+                    <input type="hidden" name="questionAsHint" value="0">
+                    <input type="checkbox" name="questionAsHint"<?php echo($values['questionAsHint'] ? ' checked="checked"' : ''); ?> /> <?php echo $LANG['LABEL_QUESTION_AS_HINT']; ?>
                 </label>
             </div>
             <div class="form-row">

--- a/lang/de.php
+++ b/lang/de.php
@@ -47,6 +47,7 @@ $LANG['LABEL_TAKE'] = 'Max. Anzahl Caches (1 bis 500)';
 $LANG['LABEL_CACHE_TYPE'] = 'Cache Typ';
 $LANG['LABEL_HINT_CACHE_TYPE'] = 'Garmin GPS Geräte unterstützen keine Adventure Labs. Vielleicht willst Du sie lieber als virtuelle Caches exportieren.';
 $LANG['LABEL_INCLUDE_QUESTION'] = 'Frage zur Station in Beschreibung einfügen';
+$LANG['LABEL_QUESTION_AS_HINT'] = 'Frage zur Station im Hint speichern';
 $LANG['LABEL_INCLUDE_DESCRIPTION'] = 'Beschreibung der Station in Cache Beschreibung einfügen';
 $LANG['LABEL_INCLUDE_CACHE_DESCRIPTION'] = 'Beschreibung des Adventure Labs in Cache Beschreibung einfügen';
 $LANG['LABEL_INCLUDE_AWARD'] = 'Tagebucheinträge in Cache Beschreibung einfügen <i>(kann Spoiler enthalten)</i>';

--- a/lang/en.php
+++ b/lang/en.php
@@ -47,6 +47,7 @@ $LANG['LABEL_TAKE'] = 'Max Caches (1 to 500)';
 $LANG['LABEL_CACHE_TYPE'] = 'Cache Type';
 $LANG['LABEL_HINT_CACHE_TYPE'] = 'Garmin GPS devices do not support Adventure Labs. You probably want to export them as virtual caches.';
 $LANG['LABEL_INCLUDE_QUESTION'] = 'Include Waypoint question in Cache description';
+$LANG['LABEL_QUESTION_AS_HINT'] = 'Write Waypoint question into Hint';
 $LANG['LABEL_INCLUDE_DESCRIPTION'] = 'Include description of the Waypoint in Cache description';
 $LANG['LABEL_INCLUDE_CACHE_DESCRIPTION'] = 'Include the description of the Adventure Lab in the Cache description';
 $LANG['LABEL_INCLUDE_AWARD'] = 'Include Award Message in Cache description <i>(may contain spoilers)</i>';

--- a/src/Exporter/GpxExporter.php
+++ b/src/Exporter/GpxExporter.php
@@ -95,6 +95,12 @@ class GpxExporter extends AbstractExporter
 
                 $description = $this->getWaypointDescription($cache, $values, $wpt);
 
+                if ($values['questionAsHint'] && isset($wpt['Question'])) {
+                    $hints = '>' . $this->gpxEncode($wpt['Question']) . '</groundspeak:encoded_hints>';
+                } else {
+                    $hints = ' />';
+                }
+
                 $displayStage = $this->getStageForDisplay($stage, $cache);
 
                 $waypointTitle = $this->getWaypointTitle($cache, $values, $wpt, $stage);
@@ -136,7 +142,7 @@ class GpxExporter extends AbstractExporter
                         <groundspeak:state />
                         <groundspeak:short_description html="True" />
                         <groundspeak:long_description html="True">' . $this->gpxEncode($description) . '</groundspeak:long_description>
-                        <groundspeak:encoded_hints />
+                        <groundspeak:encoded_hints'. $hints . '
                         <groundspeak:logs />
                         <groundspeak:travelbugs />
                     </groundspeak:cache>


### PR DESCRIPTION
I usually use the GPX (not waypoint) mode of lab2gpx and then export all the lab waypoints as POI to my Garmin device.
For this it would be a good idea to have the question in the "Hints" field, which is part of the POI description.
The attached merge request adds an option that adds this question to the hints field for normal GPX export (in GPX waypoint export this isn't necessary, since this variant exports the question in the waypoint description).
Maybe this is useful for others, too...